### PR TITLE
select visible messages now only selects visible messages

### DIFF
--- a/keyboard_shortcuts.js
+++ b/keyboard_shortcuts.js
@@ -50,7 +50,7 @@ $(function() {
 
           return false;
         case 65:		// A = mark all as read
-          rcmail.command('select-all');
+          rcmail.command('select-all', 'page');
           rcmail.command('mark', 'read');
           return false;
         case 67:                // C = collapse-all


### PR DESCRIPTION
It was selecting all, which was not consistent with that its label is, and is probably not actually that great of an idea for users
