### PR TITLE
Add "m" shortcut to mark selected message(s) read or unread

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
   "support": {
           "email": "cor@roundcu.be",
           "issues": "https://github.com/corbosman/keyboard_shortcuts/issues"
-      }
+      },
+    "require": {
+        "roundcube/plugin-installer": ">=0.1.3"
+    }
 }

--- a/keyboard_shortcuts.js
+++ b/keyboard_shortcuts.js
@@ -82,6 +82,19 @@ $(function() {
         case 107:		// k = next page (similar to Gmail)
           rcmail.command('nextpage');
           return false;
+        case 109:		// m = mark read/unread (similar to Thunderbird)
+          var uid = rcmail.message_list.get_selection();
+          if (uid && uid.length > 0) {
+            var mid = rcmail.message_list.rows[uid[0]].id;
+            if ($('tr#' + mid).hasClass('unread')) {
+              rcmail.command('mark', 'read');
+            } else {
+              rcmail.command('mark', 'unread');
+            }
+          } else {
+            return true;
+          }
+          return false;
         case 112:		// p = print
           if (rcmail.message_list.selection.length == 1)
           rcmail.command('print');

--- a/keyboard_shortcuts.php
+++ b/keyboard_shortcuts.php
@@ -22,6 +22,7 @@
  * f:	Forward message
  * j:	Go to previous page of messages (as Gmail)
  * k:	Go to next page of messages (as Gmail)
+ * m:	Mark message(s) read/unread (as Thunderbird)
  * p:	Print message
  * r:	Reply to message
  * R:	Reply to all of message
@@ -81,6 +82,7 @@ class keyboard_shortcuts extends rcube_plugin
         $c .= "<div class='shortcut_key'>?</div> ".$this->gettext('help')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>a</div> ".$this->gettext('selectallvisiblemessages')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>A</div> ".$this->gettext('markallvisiblemessagesasread')."<br class='clear' />";
+        $c .= "<div class='shortcut_key'>m</div> ".$this->gettext('markselected')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>c</div> ".$this->gettext('compose')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>d</div> ".$this->gettext('deletemessage')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>f</div> ".$this->gettext('forwardmessage')."<br class='clear' />";

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -6,6 +6,7 @@ $labels['show'] = 'Show';
 $labels['help'] = 'Help';
 $labels['selectallvisiblemessages'] = 'Select all visible messages';
 $labels['markallvisiblemessagesasread'] = 'Mark all visible messages as read';
+$labels['markselected'] = 'Mark selected message(s) as read or unread';
 $labels['title'] = 'Shortcuts';
 
 ?>


### PR DESCRIPTION
Hi thanks for the great plugin.

In case you were interested, I added this keyboard shortcut to toggle one or more messages' read status.

Similar to Thunderbird mail, pressing 'm' on a message will toggle its read flag.  If multiple messages are selected, it looks at the first highlighted message and uses that to set the flag for the rest.

Regards,

Drew