### PR TITLE
Adds a keyboard shortcut to return to the message list (index).

### DIFF
--- a/keyboard_shortcuts.js
+++ b/keyboard_shortcuts.js
@@ -112,6 +112,9 @@ $(function() {
         case 102:		// f = forward
           rcmail.command('forward');
           return false;
+        case 105:		// i = back to list
+          rcmail.command('list');
+          return false;
         case 106:		// j = previous message (similar to Gmail)
           rcmail.command('previousmessage');
           return false;

--- a/keyboard_shortcuts.php
+++ b/keyboard_shortcuts.php
@@ -36,7 +36,7 @@
  * Shortcuts, mail view:
  * d:	Delete message
  * f:	Forward message
- * i:	Go to back to messeage list (as Gmail)
+ * i:	Go to back to message list (as Gmail)
  * j:	Go to previous message (as Gmail)
  * k:	Go to next message (as Gmail)
  * p:	Print message

--- a/keyboard_shortcuts.php
+++ b/keyboard_shortcuts.php
@@ -36,6 +36,7 @@
  * Shortcuts, mail view:
  * d:	Delete message
  * f:	Forward message
+ * i:	Go to back to messeage list (as Gmail)
  * j:	Go to previous message (as Gmail)
  * k:	Go to next message (as Gmail)
  * p:	Print message
@@ -113,6 +114,7 @@ class keyboard_shortcuts extends rcube_plugin
         $c .= "<div class='shortcut_key'>d</div> ".$this->gettext('deletemessage')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>c</div> ".$this->gettext('compose')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>f</div> ".$this->gettext('forwardmessage')."<br class='clear' />";
+        $c .= "<div class='shortcut_key'>i</div> ".$this->gettext('backtolist')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>j</div> ".$this->gettext('previousmessage')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>k</div> ".$this->gettext('nextmessage')."<br class='clear' />";
         $c .= "<div class='shortcut_key'>p</div> ".$this->gettext('printmessage')."<br class='clear' />";


### PR DESCRIPTION
Pressing the **i** key from the message-view, returns to the message list for the current folder, using  Roundcube's `backtolist` label. Also added to the Help view (?-key).
